### PR TITLE
Updated Formatting and grammar of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Scribbltaire.io
 
-Project Name: Scribbltaire.io   
-GitHub Link: https://github.com/LeonFranco/cmpt276-namingVariablesIsHard-group-project.git   
-Webapp Link: https://scribbltaire-io.herokuapp.com
+**Project Name:** Scribbltaire.io   
+**[GitHub Link](https://github.com/LeonFranco/cmpt276-namingVariablesIsHard-group-project.git)**
+**[Webapp Link](https://scribbltaire-io.herokuapp.com)**
 
-Proposal:
-Scribbltaire.io is a game where a player guesses what is being drawn on the screen. A player can enter a game with a set of random doodles pulled from Google’s Quick Draw dataset where the objective is to correctly guess the subject of each doodle, simulating Skribbl.io without the need for friends or strangers. Skribbl.io provides a platform to play a drawing and guessing game, but requires friends and other people to play. This solitaire version, Scribbltaire.io,  will provide the drawings for guessing while absolving the social requirements of Skribbl.io. Scribbltaire.io provides entertainment through a similar venue to Skribbl.io, engaging players that seek expressive and social gameplay. 
+**Proposal:**
+Scribbltaire.io is a single-player guessing game, where the objective is  to correctly guess the subject of each doodle drawn on the screen. Doodles are pulled, at random, from Google's [Quick Draw dataset](https://quickdraw.withgoogle.com/data). Scribbltaire.io simulates [Skribble.io](https://skribbl.io/) which is a platform to play a drawing and guessing game but with friends or strangers. This solitaire  version, Scribbltaire.io, will provide the doodles for guessing while absolving the social requirements of Skribbl.io, while still providing expressive and social gameplay.
 
 This app is a single player game, targeted at lonely people of all ages. A player can enjoy this quick and simple game without the need for friends or interacting with strangers.
 
-Scribbltaire.io has one main feature being the main game mode with subproblems such as displaying the doodle, providing feedback to players’ guesses, and tracking score. There may be variations on the main feature in the form of alternate game modes such as a timed mode where a player’s score is affected by the time it takes for them to guess the drawing. The app draws strength from the readily available source of doodles from Google’s Quick Draw dataset containing over 50 million doodles for 345 subjects to quickly generate doodles and enable a variety of game modes.
+Scribbltaire.io has one main feature being the main game mode with subproblems such as displaying the doodle, providing feedback to players’ guesses, and tracking score. There may be variations of the main feature in the form of alternate game modes such as a timed mode where a player’s score is affected by the time it takes for them to guess the drawing. The app utilizes the readily available 50 million doodles for 345 subjects from Google’s Quick Draw dataset to quickly generate doodles and enable a variety of game modes.
 
-One possible game mode may present the player with three doodles, two of which share the same subject and the third differs and the player is asked to name the odd one out by subject. Another mode may present a set of ten doodles of the same subject at once and time the player on how fast (and accurate) they can name the shared subject over several sets.
+One possible game mode will present the player with three doodles, two of which share the same subject. The player will be asked to identify the remaining odd one by subject. Another possible mode will present a set of ten doodles of the same subject at once and time the player on how fast (and accurate) they can name the shared subject over several sets.
 
-Some sample stories for this application are: “as a player, I want to select a game mode that suits my playstyle.” and “as a player, I want to view my scores so that I can look at my progress and performance in the game.” Notably, the main users we’re considering for these stories are the players and most of the actions they perform will be centered around the game. Other actions such as using a menu to exit or restart a game are stories that fit into the epic of playing Scribbltaire.io.
+Some sample stories for this application include: 
+
+ - “As a player, I want to select a game mode that suits my playstyle.” 
+ - "As a player, I want to view my scores so that I can look at my progress and performance in the game.” 
+
+The main users considered for these stories are the players themselves and actions they will perform in the game. Other actions such as using a menu to exit or restart a game are stories that fit into the epic of playing Scribbltaire.io.


### PR DESCRIPTION
REVISION 1
added in-line links to github link and webapp link
added in-line link to Skribbl.io for readers to get more information if desired

REVISION 2
"Proposal: Scribbltaire.io is a game where a player guesses what is being drawn on the screen. A player can enter a game with a set of random doodles pulled from Google’s Quick Draw dataset where the objective is to correctly guess the subject of each doodle, simulating Skribbl.io without the need for friends or strangers. Skribbl.io provides a platform to play a drawing and guessing game, but requires friends and other people to play. This solitaire version, Scribbltaire.io, will provide the drawings for guessing while absolving the social requirements of Skribbl.io. Scribbltaire.io provides entertainment through a similar venue to Skribbl.io, engaging players that seek expressive and social gameplay."
-->
"Scribbltaire.io is a single-player guessing game, where the objective is to correctly guess the subject of each doodle drawn on the screen. Doodles are pulled, at random, from Google’s Quick Draw dataset. Scribbltaire.io simulates Skribble.io which is a platform to play a drawing and guessing game but with friends or strangers. This solitaire version, Scribbltaire.io, will provide the doodles for guessing while absolving the social requirements of Skribbl.io, while still providing expressive and social gameplay."

Combined the first three sentences to remove redundant explanation of the objective of the game. Replaced "drawings" with doodles, so that only one term is used to describe the images.

REVISION 3
"The app draws strength from the readily available source of doodles from Google’s Quick Draw dataset containing over 50 million doodles for 345 subjects to quickly generate doodles and enable a variety of game modes."
-->
"The app utilizes the readily available 50 million doodles for 345 subjects from Google’s Quick Draw dataset to quickly generate doodles and enable a variety of game modes."

Restructured the sentence. Replaced "draws strength" with "utilizes".

REVISION 4 
"One possible game mode may present the player with three doodles, two of which share the same subject and the third differs and the player is asked to name the odd one out by subject."
-->
"One possible game mode will present the player with three doodles, two of which share the same subject. The player will be asked to identify the remaining odd one by subject"

Separated the sentence into two concise sentences that connect the two concepts (what the game mode is and what the player must do) coherently.

"Another mode may present a set of ten doodles of the same subject at once and time the player on how fast (and accurate) they can name the shared subject over several sets."
-->
"Another possible mode will present a set of ten doodles of the same subject at once and time the player on how fast (and accurate) they can name the shared subject over several sets"

Reworded "Another mode may" to "Another possible mode" to remove hedging due to the use of "may".

REVISION 5
Displayed the user stories as a list for ease of reading

"Notably, the main users we’re considering for these stories are the players and most of the actions they perform will be centered around the game."
-->
"The main users considered for these stories are the players themselves and actions they will perform in the game."

Removed metadiscourse through the use of "Notably". Removed the pronouns "we're". Added "themselves" after players to remove confusion and emphasize that the user stories are targetting the players. Reworded the end of the sentence to concisely talk about the actions the users perform in the game.

These revisions were part of an assignment for CMPT376. They are based on the teachings of the class. If you feel the changes are satisfactory and adequate, please accept the pull request.